### PR TITLE
Identify file types to make git diff results clearer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,157 @@
+# Auto detect text files and perform LF normalization
+*          text=auto
+# Documents
+*.bibtex   text diff=bibtex
+*.doc      diff=astextplain
+*.DOC      diff=astextplain
+*.docx     diff=astextplain
+*.DOCX     diff=astextplain
+*.dot      diff=astextplain
+*.DOT      diff=astextplain
+*.pdf      diff=astextplain
+*.PDF      diff=astextplain
+*.rtf      diff=astextplain
+*.RTF      diff=astextplain
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text
+*.csv      text eol=crlf
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+*.epub     diff=astextplain
+
+# Graphics
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.tif      binary
+*.tiff     binary
+*.ico      binary
+# SVG treated as text by default.
+*.svg      text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg    binary
+*.eps      binary
+
+# Scripts
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.ksh      text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+# These are explicitly windows files and should use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# Serialisation
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.bz       binary
+*.bz2      binary
+*.bzip2    binary
+*.gz       binary
+*.lz       binary
+*.lzma     binary
+*.rar      binary
+*.tar      binary
+*.taz      binary
+*.tbz      binary
+*.tbz2     binary
+*.tgz      binary
+*.tlz      binary
+*.txz      binary
+*.xz       binary
+*.Z        binary
+*.zip      binary
+*.zst      binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+#
+# Exclude files from exporting
+#
+
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore
+
+# Apply override to all files in the directory
+*.md     linguist-detectable
+
+# Sources
+*.c        text diff=cpp
+*.cc       text diff=cpp
+*.cxx      text diff=cpp
+*.cpp      text diff=cpp
+*.cpi      text diff=cpp
+*.c++      text diff=cpp
+*.hpp      text diff=cpp
+*.h        text diff=cpp
+*.h++      text diff=cpp
+*.hh       text diff=cpp
+*.pxd      text diff=python
+*.py       text diff=python
+*.py3      text diff=python
+*.pyw      text diff=python
+*.pyx      text diff=python
+*.pyz      text diff=python
+*.pyi      text diff=python
+
+# Binary files
+# ============
+*.db       binary
+*.p        binary
+*.pkl      binary
+*.pickle   binary
+*.pyc      binary export-ignore
+*.pyo      binary export-ignore
+*.pyd      binary
+
+# Jupyter notebook
+*.ipynb    text eol=lf
+
+# Compiled Object files
+*.slo      binary
+*.lo       binary
+*.o        binary
+*.obj      binary
+
+# Precompiled Headers
+*.gch      binary
+*.pch      binary
+
+# Compiled Dynamic libraries
+*.so       binary
+*.dylib    binary
+*.dll      binary
+
+# Compiled Static libraries
+*.lai      binary
+*.la       binary
+*.a        binary
+*.lib      binary
+
+# Executables
+*.exe      binary
+*.out      binary
+*.app      binary
+
+
+# These are binary data files
+*.bin      binary
+*.ttf      binary


### PR DESCRIPTION
When I git diff upstream/redesign , the contents of the binary file were output. Adding .gitattributes solved this problem.

Template from https://github.com/gitattributes/gitattributes.